### PR TITLE
Resolve CNAME records correctly when an A record is queried

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,12 @@
 'use strict';
 
-var server = require('./server');
+var DnsApiServer = require('./server');
 
 if (process.argv.length < 5) {
   console.error('Example usage: node src/index.js test/fixtures/certs/ 53 5300 box.knilxof.org');
   return;
 }
-server.serve.apply(undefined, process.argv.slice(2));
+
+let server = new DnsApiServer();
+
+DnsApiServer.prototype.serve.apply(server, process.argv.slice(2));


### PR DESCRIPTION
If a CNAME exists for a name, when an A is requested it should respond with a CNAME record.

This also moves the server into a instantiable.
