### PR TITLE
Deal with multiple output lines in host command output

### DIFF
--- a/client/proxy.js
+++ b/client/proxy.js
@@ -10,6 +10,7 @@ var os = require('os');
 var args = process.argv;
 if (args.length < 7) {
   console.log('Usage: node ./proxy.js ns.useraddress.net box.useraddress.net 108.61.190.188 8000 4334');
+  console.log('You sent', args);
   return;
 }
 

--- a/client/run.sh
+++ b/client/run.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
 npm install http-proxy
-node proxy.js $1 $2 `host $1 | cut -d ' ' -f 4` 8000 4334 &
+
+# The `| head -1 | cut -d ' ' -f 4` commands will extract the IP address
+# from the `host` command's output, which would look like:
+
+# knilxof.org has address 52.39.215.79
+# knilxof.org mail is handled by 50 fb.mail.gandi.net.
+# knilxof.org mail is handled by 10 spool.mail.gandi.net.
+
+node proxy.js $1 $2 `host $1 | head -1 | cut -d ' ' -f 4` 8000 4334 &
 python -m SimpleHTTPServer 8000 &
 sleep 10
 cd scripts


### PR DESCRIPTION
On my machine, `host knilxof.org` gives multiple lines of output:

``` bash
Michiels-Laptop:client Michiel$ host knilxof.org
knilxof.org has address 52.39.215.79
knilxof.org mail is handled by 50 fb.mail.gandi.net.
knilxof.org mail is handled by 10 spool.mail.gandi.net.
```

This patch is to make `client/run.sh` only use the first line and ignore the other two.

r? @Yoric 
